### PR TITLE
DELTA: Allow doctrine-bundle v2.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/config": "^5.2",
         "symfony/dependency-injection": "^5.2",
         "ramsey/uuid": "^4.1",
-        "doctrine/doctrine-bundle": "^2.3"
+        "doctrine/doctrine-bundle": "^2.2.3||^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17b938a70781b8b627ae299900992746",
+    "content-hash": "27b8b7a9f26bee940fe2cf21ae538ce3",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
# Description
MoneyMachine is not up-to-date with vendor doctrine-bundle. A bug is reported at Doctrine, in order to be able to update MoneyMachine.
However, this delays the KYC project. Therefore, this allows doctrine-bundle previous version too.